### PR TITLE
Patchelf installed binaries to use libraries from nixpgks

### DIFF
--- a/psc-package-simple.nix
+++ b/psc-package-simple.nix
@@ -1,6 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-pkgs.stdenv.mkDerivation rec {
+let dynamic-linker = pkgs.stdenv.cc.bintools.dynamicLinker;
+in pkgs.stdenv.mkDerivation rec {
   name = "psc-package-simple";
   version = "v0.4.2";
 
@@ -9,8 +10,15 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = "0h8jkxqxi44vrzwl1c5zddxjxqbzkwgmn2m7gxlgs019xlsmml4w";
   };
 
+  buildInputs = [ pkgs.gmp ];
+  libPath = pkgs.lib.makeLibraryPath buildInputs;
+  dontStrip = true;
+
   installPhase = ''
     mkdir -p $out/bin
     install -D -m555 -T psc-package $out/bin/psc-package
+    chmod u+w $out/bin/psc-package
+    patchelf --interpreter ${dynamic-linker} --set-rpath ${libPath} $out/bin/psc-package
+    chmod u-w $out/bin/psc-package
   '';
 }

--- a/purp.nix
+++ b/purp.nix
@@ -1,6 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-pkgs.stdenv.mkDerivation rec {
+let dynamic-linker = pkgs.stdenv.cc.bintools.dynamicLinker;
+in pkgs.stdenv.mkDerivation rec {
   name = "purp";
   version = "0.3.0.0";
 
@@ -9,9 +10,16 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = "0sz9mc5rdj59kxq370dffd2k4zamgxj8m3hr8d8kmzzrmpp4qk66";
   };
 
+  buildInputs = [ pkgs.gmp ];
+  libPath = pkgs.lib.makeLibraryPath buildInputs;
+  dontStrip = true;
+
   unpackPhase = ''
     mkdir -p $out/bin
     tar xf $src -C $out/bin
+    chmod u+w $out/bin/purp
+    patchelf --interpreter ${dynamic-linker} --set-rpath ${libPath} $out/bin/purp
+    chmod u-w $out/bin/purp
   '';
 
   dontInstall = true;

--- a/purs.nix
+++ b/purs.nix
@@ -1,6 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
-pkgs.stdenv.mkDerivation rec {
+let dynamic-linker = pkgs.stdenv.cc.bintools.dynamicLinker;
+in pkgs.stdenv.mkDerivation rec {
   name = "purs-simple";
   version = "v0.12.0";
 
@@ -9,8 +10,17 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = "1wf7n5y8qsa0s2p0nb5q81ck6ajfyp9ijr72bf6j6bhc6pcpgmyc";
   };
 
+  buildInputs = [ pkgs.zlib
+                  pkgs.gmp
+                  pkgs.ncurses5];
+  libPath = pkgs.lib.makeLibraryPath buildInputs;
+  dontStrip = true;
+
   installPhase = ''
     mkdir -p $out/bin
     install -D -m555 -T purs $out/bin/purs
+    chmod u+w $out/bin/purs
+    patchelf --interpreter ${dynamic-linker} --set-rpath ${libPath} $out/bin/purs
+    chmod u-w $out/bin/purs
   '';
 }

--- a/spacchetti-cli.nix
+++ b/spacchetti-cli.nix
@@ -9,9 +9,15 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = "1rgkwxhvzy5scjn5v0hf988k8sdmm3qa9agj9swxq6w2h80i1lnr";
   };
 
+  buildInputs = [ pkgs.gmp ];
+  dontStrip = true;
+
   unpackPhase = ''
     mkdir -p $out/bin
     tar xf $src -C $out/bin
+    chmod u+w $out/bin/spacchetti
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${pkgs.gmp}/lib" $out/bin/spacchetti
+    chmod u-w $out/bin/spacchetti
   '';
 
   dontInstall = true;


### PR DESCRIPTION
The installed binaries now use nixpkgs dependencies. All installed
binaries seem to work on NixOS. This change makes all non-nixos systems
use libraries such as gmp and zlib from nixpkgs instead of their native
package systems.