### PR TITLE
Fix purs-0.13.5 hash mismatch on darwin

### DIFF
--- a/purs/0.13.5.nix
+++ b/purs/0.13.5.nix
@@ -6,7 +6,7 @@ let
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
     url = "https://github.com/purescript/purescript/releases/download/v0.13.5/macos.tar.gz";
-    sha256 = "051rb2rpkrvxs00q6ivq6c009azyplsj9a9v7arv18y3cls3h3wg";
+    sha256 = "19bb50m0cd738r353blgy21d842b3yj58xfbplk7bz59jawj9lym";
   }
   else pkgs.fetchurl {
     url = "https://github.com/purescript/purescript/releases/download/v0.13.5/linux64.tar.gz";


### PR DESCRIPTION
The hash for https://github.com/purescript/purescript/releases/download/v0.13.5/macos.tar.gz was not matched.
