### PR TITLE
Add PureScript 0.13.6

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,10 @@ let
   };
 
   inputs = rec {
+    purs-0_13_6 = import ./purs/0.13.6.nix {
+      inherit pkgs;
+    };
+
     purs-0_13_5 = import ./purs/0.13.5.nix {
       inherit pkgs;
     };
@@ -42,7 +46,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_13_5;
+    purs = purs-0_13_6;
 
     purs-simple = purs;
 

--- a/purs/0.13.6.nix
+++ b/purs/0.13.6.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  version = "v0.13.6";
+
+  src = if pkgs.stdenv.isDarwin
+  then pkgs.fetchurl {
+    url = "https://github.com/purescript/purescript/releases/download/v0.13.6/macos.tar.gz";
+    sha256 = "04kwjjrriyizpvhs96jgyx21ppyd1ynblk24i5825ywxlw9hja25";
+  }
+  else pkgs.fetchurl {
+    url = "https://github.com/purescript/purescript/releases/download/v0.13.6/linux64.tar.gz";
+    sha256 = "012znrj32aq96qh1g2hscdvhl3flgihhimiz40agk0dykpksblns";
+  };
+
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}


### PR DESCRIPTION
There's a [new release of the PureScript compiler](https://github.com/purescript/purescript/releases/tag/v0.13.6), so I've added the new version to easy-purescript-nix and updated the default PureScript version to `purs-0_13_6`.

I've tested this by using `easy-purescript-nix` in a Nix shell pointing at my fork, then compiling a PureScript project using the resulting `purs` version 0.13.6, and things check out.