### PR TITLE
Allow NodeJS to be passed as an argument instead of pinning to nodejs-10_x

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {}
+, nodejs ? pkgs.nodejs-10_x # NOTE: Need to use node2nix --nodejs-10
+}:
 
 let
   easy-dhall = import ./easy-dhall.nix {
@@ -10,10 +12,7 @@ let
       inherit (pkgs) fetchurl;
     }
   ) {
-    nodejs = pkgs.nodejs-10_x;
-
-    # NOTE: Need to use node2nix --nodejs-10
-
+    inherit nodejs;
     inherit (pkgs) stdenv python2 utillinux runCommand writeTextFile;
 
     libtool = if pkgs.stdenv.isDarwin

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { pkgs ? import <nixpkgs> {}
-, nodejs ? pkgs.nodejs-10_x # NOTE: Need to use node2nix --nodejs-10
+, nodejs ? pkgs.nodejs
 }:
 
 let


### PR DESCRIPTION
I have a project in which we're using Node 11 and would like to have everything on the same version (including `easy-purescript-nix`). This PR no longer hardcodes `nodejs` as `pkgs.nodejs-10_x`, instead setting that as the fallback case if the user does not provide their own version. In that way this preserves the existing behavior but opens up the ability to change the Node version if you would like.

Tested by compiling a PureScript / JavaScript project using Parcel, Spago, spago2nix, and other tools from easy-purescript-nix based on this patch:

```
{ pkgs, nodejs }:

# 2019-12-04 nix-prefetch-git
import (pkgs.fetchFromGitHub {
  owner = "thomashoneyman";
  repo = "easy-purescript-nix";
  rev = "041dd945b6b27a768f6e6cd9057a8a0ac19ab29f";
  sha256 = "185x5db5ggiary4zvwl9kc3hrl4fpyrxf6jrz4xgg73cl5igkjgh";
}) { inherit pkgs nodejs; }
```

Using the above with the 19.09 channel in Nixpkgs causes Node 11 to be used without issue. Also see [yarn2nix](https://github.com/moretea/yarn2nix/blob/master/default.nix) for a similar approach.