### PR TITLE
Bump zephyr version to 0.2.2

### DIFF
--- a/zephyr.nix
+++ b/zephyr.nix
@@ -3,16 +3,16 @@
 pkgs.stdenv.mkDerivation rec {
   name = "zephyr";
 
-  version = "v0.2.1";
+  version = "v0.2.2";
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/coot/zephyr/releases/download/v0.2.1/macos.tar.gz";
-    sha256 = "0zwdsrs7r6ff534wrar32lk39fjai1jj4dxz4bjh3yhw63lvdqfn";
+    url = "https://github.com/coot/zephyr/releases/download/v0.2.2/x86_64-osx.tar.gz";
+    sha256 = "1fslg0h5dzrah1rkjvz9gw2s2kksmdfdkpz7a7z1akn8s6nqnd93";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/coot/zephyr/releases/download/v0.2.1/linux64.tar.gz";
-    sha256 = "0afcnpqabjs4b60grkcvz2hb3glpjhlnvqvpgc0zsdwaqnmcrrnk";
+    url = "https://github.com/coot/zephyr/releases/download/v0.2.2/x86_64-linux.tar.gz";
+    sha256 = "0kgvrd6i1yj5n09ar82q27wgq6n5x9x6iy93nx1yqvk87kcmbji6";
   };
 
   buildInputs = [ pkgs.gmp pkgs.zlib pkgs.ncurses5 ];


### PR DESCRIPTION
Based on the [new release](https://github.com/coot/zephyr/releases/tag/v0.2.2). 

Zephyr was [updated to rely on PureScript 0.13](https://github.com/coot/zephyr/pull/21) a little while ago. Later, I discovered that the pre-0.13 version of Zephyr would, on projects with many modules (1000+) sometimes fail when trying to write a directory the compiler should have produced. The current version of Zephyr avoids this issue likely due to changes in the PureScript compiler.