### PR TITLE
Update spago version to version referenced in Nix definition

### DIFF
--- a/spago.nix
+++ b/spago.nix
@@ -13,15 +13,15 @@ in
 pkgs.stdenv.mkDerivation rec {
   name = "spago";
 
-  version = "0.13.1";
+  version = "0.14.0";
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
-    url = "https://github.com/spacchetti/spago/releases/download/0.14.0/osx.tar.gz";
+    url = "https://github.com/spacchetti/spago/releases/download/${version}/osx.tar.gz";
     sha256 = "16xdawfq9x75isdsj7ixrs3rq2h4j2wvacpbfhpa2d7s3n1j6lal";
   }
   else pkgs.fetchurl {
-    url = "https://github.com/spacchetti/spago/releases/download/0.14.0/linux.tar.gz";
+    url = "https://github.com/spacchetti/spago/releases/download/${version}/linux.tar.gz";
     sha256 = "0bqpns70ik55wb5vahmrpaz480bm9nhq87iq57aj74w6v52qi3bv";
   };
 


### PR DESCRIPTION
Version 0.14.0 appears to be fetched in the definition already but the version number of the derivation wasn't updated. I modified the Nix so these would be consistent but kept the current Nix build result the same:

```sh
$ nix-build spago.nix
/nix/store/cl2apfqqspl8qbr5lywsfi29bdrbn6v0-spago

$ /nix/store/cl2apfqqspl8qbr5lywsfi29bdrbn6v0-spago/bin/spago version
0.14.0

$ nix-info
system: "x86_64-linux", multi-user?: yes, version: nix-env (Nix) 2.3.2, <redacted>, channels(root): "nixos-19.09.2036.c49da6435f3", <redacted>
```