### PR TITLE
Use `fixDarwinDylibNames` when building `zephyr`

### DIFF
--- a/zephyr.nix
+++ b/zephyr.nix
@@ -15,6 +15,9 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = "106qp9k1lnbxl7pich4i7bqj9gw8v895i3gp58dgcibgz4q8hymw";
   };
 
+  nativeBuildInputs = []
+    ++ pkgs.stdenv.lib.optional pkgs.stdenv.isDarwin pkgs.fixDarwinDylibNames;
+
   buildInputs = [ pkgs.gmp pkgs.zlib pkgs.ncurses5 ];
 
   libPath = pkgs.lib.makeLibraryPath buildInputs;
@@ -29,12 +32,6 @@ pkgs.stdenv.mkDerivation rec {
     install -D -m555 -T $out/zephyr $ZEPHYR
 
     chmod u+w $ZEPHYR
-  '' + pkgs.stdenv.lib.optionalString pkgs.stdenv.isDarwin ''
-    install_name_tool \
-      -change /usr/lib/libSystem.B.dylib ${pkgs.darwin.Libsystem}/lib/libSystem.B.dylib \
-      -change /usr/lib/libz.1.dylib ${pkgs.zlib}/lib/libz.1.dylib \
-      -change /usr/lib/libiconv.2.dylib ${pkgs.libiconv}/libiconv.2.dylib \
-      $ZEPHYR
   '' + pkgs.stdenv.lib.optionalString (!pkgs.stdenv.isDarwin) ''
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath ${libPath} $ZEPHYR
   '' + ''


### PR DESCRIPTION
Fixes the following error when building `zephyr` using Nixpkgs 19.09:

```
these derivations will be built:
  /nix/store/5xq1gnvzvq5wk2ydf4pixa90hkwbyc50-zephyr-0.3.2.drv
building '/nix/store/5xq1gnvzvq5wk2ydf4pixa90hkwbyc50-zephyr-0.3.2.drv'...
unpacking sources
install_name_tool: object: /nix/store/czckp29wprywjyh7pia4lhx5j16dsr0g-zephyr-0.3.2/bin/zephyr malformed object (unknown load command 10)
builder for '/nix/store/5xq1gnvzvq5wk2ydf4pixa90hkwbyc50-zephyr-0.3.2.drv' failed with exit code 1
error: build of '/nix/store/5xq1gnvzvq5wk2ydf4pixa90hkwbyc50-zephyr-0.3.2.drv' failed
```