### PR TITLE
Update `install-nix-action` for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v9
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-20.09
     - run: ./tests.bash


### PR DESCRIPTION
GitHub Actions has deprecated the `set-env` and `add-path` commands, which means that old versions of `install-nix-action` no longer work. 

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This PR updates to the latest `install-nix-action`, which (since version 11) now requires a `nix_path`. I've set this to 20.09, but we can use something else if desired.