### PR TITLE
Bump to spago v0.19.1

### DIFF
--- a/spago.nix
+++ b/spago.nix
@@ -13,16 +13,16 @@ in
 pkgs.stdenv.mkDerivation rec {
   pname = "spago";
 
-  version = "0.19.0";
+  version = "0.19.1";
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
     url = "https://github.com/purescript/spago/releases/download/${version}/macOS.tar.gz";
-    sha256 = "117jiy4za3xv412zn8153wkivys1v4nc2szxyzkxj0ybp9qhi7lj";
+    sha256 = "1wgz3l97by3mn6317wvvyks47bb87k0ij8hy32d29im4xq5fqi8s";
   }
   else pkgs.fetchurl {
     url = "https://github.com/purescript/spago/releases/download/${version}/Linux.tar.gz";
-    sha256 = "15pp694zgghrd4cvclvhpvgcjs93nx0ky210yk39771baxpxv51f";
+    sha256 = "1i12kmaf2cr86aj1pdnxx8jf1l59k5k5vhwf80l1msdzqlbdbj14";
   };
 
   buildInputs = [ pkgs.gmp pkgs.zlib pkgs.ncurses5 pkgs.stdenv.cc.cc.lib ];

--- a/spago.nix
+++ b/spago.nix
@@ -13,16 +13,16 @@ in
 pkgs.stdenv.mkDerivation rec {
   pname = "spago";
 
-  version = "0.18.1";
+  version = "0.19.0";
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
     url = "https://github.com/purescript/spago/releases/download/${version}/macOS.tar.gz";
-    sha256 = "0bzswl0lz64lahxjrb0mwr7ykv4g181mivhvp5y2pggmczbrm2yh";
+    sha256 = "117jiy4za3xv412zn8153wkivys1v4nc2szxyzkxj0ybp9qhi7lj";
   }
   else pkgs.fetchurl {
     url = "https://github.com/purescript/spago/releases/download/${version}/Linux.tar.gz";
-    sha256 = "10c9njn3lp37wj1jyzqpyjjksrxipidkpjmbb90x68q0wzf688c7";
+    sha256 = "15pp694zgghrd4cvclvhpvgcjs93nx0ky210yk39771baxpxv51f";
   };
 
   buildInputs = [ pkgs.gmp pkgs.zlib pkgs.ncurses5 pkgs.stdenv.cc.cc.lib ];


### PR DESCRIPTION
https://github.com/purescript/spago/releases/tag/0.19.1

```sh
$ nix-prefetch-url "https://github.com/purescript/spago/releases/download/0.19.1/Linux.tar.gz"                  
[8.5 MiB DL]
path is '/nix/store/ni2kd76bfbfkzxh1w8dli5fnvp0z1c5y-Linux.tar.gz'
1i12kmaf2cr86aj1pdnxx8jf1l59k5k5vhwf80l1msdzqlbdbj14
$ nix-prefetch-url "https://github.com/purescript/spago/releases/download/0.19.1/macOS.tar.gz"                  
[3.7 MiB DL]
path is '/nix/store/araz8nrzmxc6ylvx0agcszx3kabc1qyj-macOS.tar.gz'
1wgz3l97by3mn6317wvvyks47bb87k0ij8hy32d29im4xq5fqi8s

```