### PR TITLE
purs 0.14.1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 let
   easy-dhall = import ./easy-dhall.nix {
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_14_1 = import ./purs/0.14.1.nix {
+      inherit pkgs;
+    };
+
     purs-0_14_0 = import ./purs/0.14.0.nix {
       inherit pkgs;
     };
@@ -38,7 +42,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_14_0;
+    purs = purs-0_14_1;
 
     purs-simple = purs;
 
@@ -97,7 +101,8 @@ inputs // {
 
   buildInputs = buildInputs;
 
-  shell = pkgs.runCommand "easy-purescript-nix-shell" {
-    buildInputs = buildInputs;
-  } "";
+  shell = pkgs.runCommand "easy-purescript-nix-shell"
+    {
+      buildInputs = buildInputs;
+    } "";
 }

--- a/purs/0.14.1.nix
+++ b/purs/0.14.1.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  version = "v0.14.1";
+
+  src =
+    if pkgs.stdenv.isDarwin
+    then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+          sha256 = "1m2xpnf6npnp1dgwqd1fcfbl6nq1p2k7fbz0jsywx3d6hdn1w7hv";
+        }
+    else
+      pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+        sha256 = "1j3g5l0aqqfw8clra36ddnl55ir9k8yqbndnp04ya7s4vwr1hr2v";
+      };
+
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}


### PR DESCRIPTION
https://github.com/purescript/purescript/releases/tag/v0.14.1

```
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.1/macos.tar.gz"
path is '/nix/store/rzn743da4khnbfrrcij4cdnlx3d11bij-macos.tar.gz'
1m2xpnf6npnp1dgwqd1fcfbl6nq1p2k7fbz0jsywx3d6hdn1w7hv
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.1/linux64.tar.gz"
path is '/nix/store/6ndylbmzhyfhlwgsrgq8mccv0isc68lh-linux64.tar.gz'
1j3g5l0aqqfw8clra36ddnl55ir9k8yqbndnp04ya7s4vwr1hr2v
```