### PR TITLE
spago2nix: 898798204fa8f53837bbcf71e30aeb425deb0906

### DIFF
--- a/spago2nix.nix
+++ b/spago2nix.nix
@@ -1,12 +1,13 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
-import (
-  pkgs.fetchFromGitHub {
-    owner = "justinwoo";
-    repo = "spago2nix";
-    rev = "704fc193dd1066d3bee91e525ad5ea4876ad990e";
-    sha256 = "1g82s3wz18lxif3pdd9nk6vb3c5cy1i1w5xpkl9gpvc44x8w7lrl";
-  }
-) {
+import
+  (
+    pkgs.fetchFromGitHub {
+      owner = "justinwoo";
+      repo = "spago2nix";
+      rev = "a4622c3b27fca47e3276131a8ec4097a1d3c78a7";
+      sha256 = "1v7mpzqx9hwfk7xz1vyf3xf2ry7zb7658mh11r7d2avb311b1xw2";
+    }
+  ) {
   inherit pkgs;
 }


### PR DESCRIPTION
There's still a big flaw in that this is _not_ compatible with the latest spago because of `list-pacakges` vs `ls`, but at least this is the version from the latest main branch