### PR TITLE
purs: 0.14.1 → 0.14.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_14_2 = import ./purs/0.14.2.nix {
+      inherit pkgs;
+    };
+
     purs-0_14_1 = import ./purs/0.14.1.nix {
       inherit pkgs;
     };
@@ -42,7 +46,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_14_1;
+    purs = purs-0_14_2;
 
     purs-simple = purs;
 

--- a/purs/0.14.2.nix
+++ b/purs/0.14.2.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  version = "v0.14.2";
+
+  src =
+    if pkgs.stdenv.isDarwin
+    then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+          sha256 = "1ga2hn9br71dyzn3p9jvjiksvnq21p6i5hp1z1j5fpz9la28nqzf";
+        }
+    else
+      pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+        sha256 = "1kv7dm1nw85lw3brrclkj7xc9p021jx3n8wgp2fg3572s86ypskw";
+      };
+
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}


### PR DESCRIPTION
https://github.com/purescript/purescript/releases/tag/v0.14.2

```console
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.2/linux64.tar.gz"
path is '/nix/store/7x3anmcj2m0l0zllairyymai5a06phb3-linux64.tar.gz'
1kv7dm1nw85lw3brrclkj7xc9p021jx3n8wgp2fg3572s86ypskw
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.2/macos.tar.gz"
path is '/nix/store/wvfp718kjxqa0xab07jcr7mrprlbmdaa-macos.tar.gz'
1ga2hn9br71dyzn3p9jvjiksvnq21p6i5hp1z1j5fpz9la28nqzf
```