### PR TITLE
purs: 0.14.2 → 0.14.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_14_3 = import ./purs/0.14.3.nix {
+      inherit pkgs;
+    };
+
     purs-0_14_2 = import ./purs/0.14.2.nix {
       inherit pkgs;
     };
@@ -46,7 +50,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_14_2;
+    purs = purs-0_14_3;
 
     purs-simple = purs;
 

--- a/purs/0.14.3.nix
+++ b/purs/0.14.3.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  version = "v0.14.3";
+
+  src =
+    if pkgs.stdenv.isDarwin
+    then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+          sha256 = "1ipksp6kx3h030xf1y3y30gazrdz893pklanwak27hbqfy3ckssj";
+        }
+    else
+      pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+        sha256 = "158jyjpfgd84gbwpxqj41mvpy0fmb1d1iqq2h42sc7041v2f38p0";
+      };
+
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}


### PR DESCRIPTION
https://github.com/purescript/purescript/releases/tag/v0.14.3

```console
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.3/linux64.tar.gz"             
path is '/nix/store/0fnw9k854qn30pnw9b82zbvf7nilwqdc-linux64.tar.gz'
158jyjpfgd84gbwpxqj41mvpy0fmb1d1iqq2h42sc7041v2f38p0
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.3/macos.tar.gz"               
path is '/nix/store/dddg704ndg28vqis5v864yrknvrzhhrx-macos.tar.gz'
1ipksp6kx3h030xf1y3y30gazrdz893pklanwak27hbqfy3ckssj
```

---

I would appreciate if I could get some feedback on my other PR #146 because I can't work with this on Nix unstable because of `stdenv.lib` being deprecated and the old  `node2nix` version `1.8.0` using it; that PR reran `node2nix 1.9.0` on all NPM packages.