### PR TITLE
Swap buildInput and nativeBuildInput for `purs-tidy`

### DIFF
--- a/purs-tidy/default.nix
+++ b/purs-tidy/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> { inherit system; }
 , system ? builtins.currentSystem
 , nodejs ? pkgs.nodejs
-, purs
+, purs ? (import ../default.nix { inherit pkgs; }).purs-0_14_3
 }:
 
 let
@@ -22,13 +22,13 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = "sha256-1woVnlv+7e3REHFdEHyRNxb5RsoSUHiI+JnnBl24BqQ=";
   };
 
-  buildInputs = [
+  buildInputs = [ nodejs ];
+  nativeBuildInputs = [
     spagoPkgs.installSpagoStyle
     spagoPkgs.buildSpagoStyle
     spagoPkgs.buildFromNixStore
     purs
   ];
-  nativeBuildInputs = [ nodejs ];
 
   # this allows us to drop the package.json file all together
   patchPhase = ''


### PR DESCRIPTION
I goofed. These are easy to forget which is which. A user didn't have `node` already on the path unlike myself an the tests for this repo.

I also provided a default `purs`, but I'm not sure if this is the best way to do it.

Closes smilack's [Discourse issue](https://discourse.purescript.org/t/announcing-purs-tidy-a-syntax-tidy-upper-for-purescript/2524/15)