### PR TITLE
purs-tidy: 0.4.0 → 0.4.1

### DIFF
--- a/purs-tidy/default.nix
+++ b/purs-tidy/default.nix
@@ -1,6 +1,8 @@
 { pkgs ? import <nixpkgs> { inherit system; }
 , system ? builtins.currentSystem
+  # node: >=14
 , nodejs ? pkgs.nodejs
+  # purs: ~0.14.3
 , purs ? (import ../default.nix { inherit pkgs; }).purs-0_14_3
 }:
 
@@ -14,12 +16,12 @@ let
 in
 pkgs.stdenv.mkDerivation rec {
   pname = "purs-tidy";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = pkgs.fetchgit {
     url = "https://github.com/natefaubion/purescript-tidy.git";
     rev = "v${version}";
-    sha256 = "sha256-B+bhH2SovdibRPAtwfDkpw203/h0bL9r9Lvz/7jY4sU=";
+    sha256 = "sha256-WvJyZwRsGy28kYHrTTSZQiZJEpONFiLem8n4rUETqYQ=";
   };
 
   buildInputs = [ nodejs ];

--- a/purs-tidy/spago-packages.nix
+++ b/purs-tidy/spago-packages.nix
@@ -67,11 +67,11 @@ let
 
     "arraybuffer-types" = pkgs.stdenv.mkDerivation {
         name = "arraybuffer-types";
-        version = "v3.0.0";
+        version = "v3.0.1";
         src = pkgs.fetchgit {
           url = "https://github.com/purescript-contrib/purescript-arraybuffer-types.git";
-          rev = "c15bd045c847a401531aab32c3e60ce94f2c5227";
-          sha256 = "19dh4k3n1lr8hbj15ivkiv1886s1q7brl9hic6zrkrr2rx1bz69r";
+          rev = "48cd7f4887791db1d9c2daf5fd98b62ba00e15bd";
+          sha256 = "09r6bhsiq9iqdsjf9p8m3p31qkszsipsafvy836mfdi8af6h5fv6";
         };
         phases = "installPhase";
         installPhase = "ln -s $src $out";


### PR DESCRIPTION
I got some clarification on what the versions should be. The were added
to the `purs-tidy` README, and I added as comments to help anyone
needing to update in the future.