### PR TITLE
purs-tidy: 0.4.1 → 0.4.2 + clean up 

### DIFF
--- a/purs-tidy/default.nix
+++ b/purs-tidy/default.nix
@@ -7,21 +7,25 @@
 }:
 
 let
-  # one should be able to regenarate using process substitution
+  # one should be able to regenarate using process substitution, but spago 
+  # issue #472
   # ```fish
   # spago2nix generate 4 -- \
   #   --config (echo "https://raw.githubusercontent.com/natefaubion/purescript-tidy/v${version}/bin/spago.dhall" | psub)
   # ```
+  # but you can create a temp file with the echo’d URL for spago2nix and spago 
+  # to call
   spagoPkgs = import ./spago-packages.nix { inherit pkgs; };
 in
 pkgs.stdenv.mkDerivation rec {
   pname = "purs-tidy";
-  version = "0.4.1";
+  version = "0.4.2";
 
-  src = pkgs.fetchgit {
-    url = "https://github.com/natefaubion/purescript-tidy.git";
+  src = pkgs.fetchFromGitHub {
+    owner = "natefaubion";
+    repo = "purescript-tidy";
     rev = "v${version}";
-    sha256 = "sha256-WvJyZwRsGy28kYHrTTSZQiZJEpONFiLem8n4rUETqYQ=";
+    sha256 = "sha256-GmsCiB+RIqqh2BFY2YXvmoOiCzrGYdJ2RmRlfHv8zD8=";
   };
 
   buildInputs = [ nodejs ];
@@ -45,7 +49,6 @@ pkgs.stdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
-    ls -a
     build-spago-style "./src/**/*.purs" "./bin/**/*.purs"
   '';
 

--- a/purs-tidy/spago-packages.nix
+++ b/purs-tidy/spago-packages.nix
@@ -547,11 +547,11 @@ let
 
     "node-workerbees" = pkgs.stdenv.mkDerivation {
         name = "node-workerbees";
-        version = "v0.1.2";
+        version = "v0.2.1";
         src = pkgs.fetchgit {
           url = "https://github.com/natefaubion/purescript-node-workerbees.git";
-          rev = "5ab52953b64f05b97e8605755708e483c3c44722";
-          sha256 = "1flv690spzb5xacvjc4dp941l9dgz3qa28wv0fpvwsrff09zfwwj";
+          rev = "6b688b79920920fe0b3df418bf227f75f373c54e";
+          sha256 = "1vkx9y0fyqvqfbkgdrxphhja71g282p38yrnfh39jznf3141610j";
         };
         phases = "installPhase";
         installPhase = "ln -s $src $out";


### PR DESCRIPTION
remove unnecessary `ls` and uses `fetchFromGitHub` which gets the
tarball — which is faster. Also adding more comments about how to
upgrade spago packages.

Upgrade: 0.4.1 → 0.4.2
https://github.com/natefaubion/purescript-tidy/releases/tag/v0.4.2