### PR TITLE
purescript-language-server: 0.15.2 → 0.15.4

### DIFF
--- a/purescript-language-server/default.nix
+++ b/purescript-language-server/default.nix
@@ -4,6 +4,8 @@
 }:
 
 let
+  version = "0.15.4";
+
   nodeEnv = import ./node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile;
     inherit pkgs nodejs;
@@ -15,6 +17,6 @@ let
     inherit nodeEnv;
   };
 
-  source = nodePackage.sources."purescript-language-server-0.15.2".src;
+  source = nodePackage.sources."purescript-language-server-${version}".src;
 in
 nodeEnv.buildNodePackage (nodePackage.args // { src = source; })

--- a/purescript-language-server/node-packages.nix
+++ b/purescript-language-server/node-packages.nix
@@ -13,13 +13,13 @@ let
         sha1 = "e8fbf374dc556ff8947a10dcb0572d633f2cfa10";
       };
     };
-    "purescript-language-server-0.15.2" = {
+    "purescript-language-server-0.15.4" = {
       name = "purescript-language-server";
       packageName = "purescript-language-server";
-      version = "0.15.2";
+      version = "0.15.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/purescript-language-server/-/purescript-language-server-0.15.2.tgz";
-        sha512 = "dlxcc6Fv7rcXO3uFVcOgZturcKknB4J00ITJjZCrORTjw5eVbGcSTKrSeSAlNZWaUYu0HQX9NHVKtHDG/6rBNw==";
+        url = "https://registry.npmjs.org/purescript-language-server/-/purescript-language-server-0.15.4.tgz";
+        sha512 = "llUv605I8yvraO98rb5RmmqPdpWBno7IpIlgNlX3Nq3Q4lvB7G0OxGK89JuAoVZ8T/xkTzhjyuzw0sty0DoY3Q==";
       };
     };
     "shell-quote-1.7.2" = {
@@ -107,11 +107,11 @@ let
   args = {
     name = "purescript-language-server";
     packageName = "purescript-language-server";
-    version = "0.15.2";
+    version = "0.15.4";
     src = ./.;
     dependencies = [
       sources."isexe-2.0.0"
-      sources."purescript-language-server-0.15.2"
+      sources."purescript-language-server-0.15.4"
       sources."shell-quote-1.7.2"
       sources."uuid-3.4.0"
       sources."vscode-jsonrpc-6.0.0"

--- a/tests.bash
+++ b/tests.bash
@@ -29,7 +29,7 @@ which pscid
 pscid --version
 
 which purescript-language-server
-# purescript-language-server --version
+purescript-language-server --version
 
 which purs-tidy
 purs-tidy --version


### PR DESCRIPTION
https://github.com/nwolverson/purescript-language-server/releases

Also adds test call for version, fixes #116 -- which was fixed at init, but wasn't mentioned or closed yet