### PR TITLE
purescript: 0.14.4 → 0.14.5

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_14_5 = import ./purs/0.14.5.nix {
+      inherit pkgs;
+    };
+
     purs-0_14_4 = import ./purs/0.14.4.nix {
       inherit pkgs;
     };
@@ -54,7 +58,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_14_4;
+    purs = purs-0_14_5;
 
     purs-simple = purs;
 

--- a/purs/0.14.5.nix
+++ b/purs/0.14.5.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  version = "v0.14.5";
+
+  src =
+    if pkgs.stdenv.isDarwin
+    then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+          sha256 = "1brvbpzr3cwls809fl0sjrm9cbh8v7maf5d7ic2mha0xapabgfpv";
+        }
+    else
+      pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+        sha256 = "1mvxvn30iyrq0ck6g08f925gxnnhbfgl29b2gjjsmm3m9mpll7ws";
+      };
+
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}


### PR DESCRIPTION
https://github.com/purescript/purescript/releases/tag/v0.14.5

```console
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.5/macos.tar.gz"
path is '/nix/store/ws1b4ksvxf341s0knn3lp6744bj18rgp-macos.tar.gz'
1brvbpzr3cwls809fl0sjrm9cbh8v7maf5d7ic2mha0xapabgfpv
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.5/linux64.tar.gz"
path is '/nix/store/rkww9sisvri0p4j7229scvlrssfsr8gb-linux64.tar.gz'
1mvxvn30iyrq0ck6g08f925gxnnhbfgl29b2gjjsmm3m9mpll7ws
```