### PR TITLE
Make spago2nix’s nodejs overridable

### DIFF
--- a/spago2nix.nix
+++ b/spago2nix.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import <nixpkgs> { }
+, nodejs ? pkgs."nodejs-14_x"
+}:
 
 import
   (
@@ -10,5 +12,5 @@ import
     }
   )
 {
-  inherit pkgs;
+  inherit pkgs nodejs;
 }


### PR DESCRIPTION
Matches the API for the node2nix-generated packages in making this overridable. Could fix issues in the future when 12 and 14 get deprecated and people need a fast way to get up and running again. I tested v14 on my machine to override v10 via this patch and it worked for me.