### PR TITLE
spago: 0.20.5 → 0.20.7

### DIFF
--- a/spago.nix
+++ b/spago.nix
@@ -13,16 +13,16 @@ in
 pkgs.stdenv.mkDerivation rec {
   pname = "spago";
 
-  version = "0.20.5";
+  version = "0.20.7";
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
     url = "https://github.com/purescript/spago/releases/download/${version}/macOS.tar.gz";
-    sha256 = "0yg4nbnngjfzihy86m5qcvi4zmpyfd4x8260x5jq7pb376bblan2";
+    sha256 = "0s5zgz4kqglsavyh7h70zmn16vayg30alp42w3nx0zwaqkp79xla";
   }
   else pkgs.fetchurl {
     url = "https://github.com/purescript/spago/releases/download/${version}/Linux.tar.gz";
-    sha256 = "1k1c22qv3g30f5awggdjiwxi7aifssfmcvnpjk391cssihj9k2y0";
+    sha256 = "0bh15dr1fg306kifqipnakv3rxab7hjfpcfzabw7vmg0gsfx8xka";
   };
 
   buildInputs = [ pkgs.gmp pkgs.zlib pkgs.ncurses5 pkgs.stdenv.cc.cc.lib ];


### PR DESCRIPTION
https://github.com/purescript/spago/releases/tag/0.20.7

```console
$ nix-prefetch-url "https://github.com/purescript/spago/releases/download/0.20.7/Linux.tar.gz"
path is '/nix/store/vdmvldzcyx8v54wkxxd4qipy13i0msjn-Linux.tar.gz'
0bh15dr1fg306kifqipnakv3rxab7hjfpcfzabw7vmg0gsfx8xka
$ nix-prefetch-url "https://github.com/purescript/spago/releases/download/0.20.7/macOS.tar.gz"
path is '/nix/store/c6837lfjigbmnc99i3s7pn7v7mgbxnzf-macOS.tar.gz'
0s5zgz4kqglsavyh7h70zmn16vayg30alp42w3nx0zwaqkp79xla
```