### PR TITLE
Add purs 0.14.6 and 0.14.7

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_14_6 = import ./purs/0.14.6.nix {
+      inherit pkgs;
+    };
+
     purs-0_14_5 = import ./purs/0.14.5.nix {
       inherit pkgs;
     };
@@ -58,7 +62,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_14_5;
+    purs = purs-0_14_6;
 
     purs-simple = purs;
 

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_14_7 = import ./purs/0.14.7.nix {
+      inherit pkgs;
+    };
+
     purs-0_14_6 = import ./purs/0.14.6.nix {
       inherit pkgs;
     };
@@ -62,7 +66,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_14_6;
+    purs = purs-0_14_7;
 
     purs-simple = purs;
 

--- a/purs/0.14.6.nix
+++ b/purs/0.14.6.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  version = "v0.14.6";
+
+  src =
+    if pkgs.stdenv.isDarwin
+    then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+          sha256 = "0yfl4galaqzbbkql2vfsg4zrc5cv037286764kv8qibdk2yrhap3";
+        }
+    else
+      pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+        sha256 = "01mf850a9jhqba6a3hsbl9fjxp2khplwnlr15wzp637s5vf7rd79";
+      };
+
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}

--- a/purs/0.14.7.nix
+++ b/purs/0.14.7.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  version = "v0.14.7";
+
+  src =
+    if pkgs.stdenv.isDarwin
+    then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+          sha256 = "0pc07xv5h7jgiy04rcrnsjb97nk5zs7jrvcsqggn0izlnrcyi8rc";
+        }
+    else
+      pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+        sha256 = "0vcjxb1v76wg4hmisnw0pp6wl0pwp4fa19cw08zdhgy62w06mqfa";
+      };
+
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}


### PR DESCRIPTION
`0.14.6` - https://github.com/purescript/purescript/releases/tag/v0.14.6
```
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.6/macos.tar.gz"
[6.0 MiB DL]
path is '/nix/store/03nss7dmvnrdda4zwpff53pmbc1mb6g6-macos.tar.gz'
0yfl4galaqzbbkql2vfsg4zrc5cv037286764kv8qibdk2yrhap3
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.6/linux64.tar.gz"
[10.3 MiB DL]
path is '/nix/store/l9blmc7dx92wj9wqy3a2xz0vrfba963m-linux64.tar.gz'
01mf850a9jhqba6a3hsbl9fjxp2khplwnlr15wzp637s5vf7rd79
```
`0.14.7` - https://github.com/purescript/purescript/releases/tag/v0.14.7
```
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.7/macos.tar.gz"
[6.0 MiB DL]
path is '/nix/store/1cf33jgagfnz1msmbnzqwpja5cpc9xyq-macos.tar.gz'
0pc07xv5h7jgiy04rcrnsjb97nk5zs7jrvcsqggn0izlnrcyi8rc
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.14.7/linux64.tar.gz"
[10.3 MiB DL]
path is '/nix/store/0brhmkdmyrvcizqshbwrng1a63y8a7xi-linux64.tar.gz'
0vcjxb1v76wg4hmisnw0pp6wl0pwp4fa19cw08zdhgy62w06mqfa
```