### PR TITLE
purs: add 0.15.0-alpha-01

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_15_0-alpha-01 = import ./purs/0.15.0-alpha-01.nix {
+      inherit pkgs;
+    };
+
     purs-0_14_7 = import ./purs/0.14.7.nix {
       inherit pkgs;
     };

--- a/purs/0.15-alpha-01.nix
+++ b/purs/0.15-alpha-01.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  version = "v0.15.0-alpha-01";
+
+  src =
+    if pkgs.stdenv.isDarwin
+    then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+          sha256 = "1vsm7fjdm463hq4k1xwm1kmjq3rbivxyx5s2zmzbbxwjqqsmimhx";
+        }
+    else
+      pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+        sha256 = "11y6bsscm0qcn6y619qvgfyxb9mzpd3pk7gqd024a91ipxr5gj4w";
+      };
+
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}


### PR DESCRIPTION
Unsure if alpha releases are desired in the repository, however it would
allow easy users to easily get their hands on and test the alpha for the
main PureScript project. There could be cases made that this could just
be called `alpha` and update the URLs as alphas roll out to not pollute
the `default.nix`, or this merge request could be left open but unmerged
until there’s a beta, RC, or stable release, but having a diff users
could look at to fetch and use it themselves. I’m open to anything.

---

https://github.com/purescript/purescript/releases/tag/v0.15.0-alpha-01

```console
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.0-alpha-01/linux64.tar.gz"
path is '/nix/store/23ql57qp7ndpr6accx3lyl9jl9n6igzl-linux64.tar.gz'
11y6bsscm0qcn6y619qvgfyxb9mzpd3pk7gqd024a91ipxr5gj4w
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.0-alpha-01/macos.tar.gz"
path is '/nix/store/9m80x7s1vxs2jw9xapsf5471y5aj4529-macos.tar.gz'
1vsm7fjdm463hq4k1xwm1kmjq3rbivxyx5s2zmzbbxwjqqsmimhx
```