### PR TITLE
purs: 0.14.7 → 0.15.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_15_0 = import ./purs/0.15.0.nix {
+      inherit pkgs;
+    };
+
     purs-0_15_0-alpha-02 = import ./purs/0.15.0-alpha-02.nix {
       inherit pkgs;
     };
@@ -70,7 +74,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_14_7;
+    purs = purs-0_15_0;
 
     purs-simple = purs;
 

--- a/purs/0.15.0.nix
+++ b/purs/0.15.0.nix
@@ -1,0 +1,30 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  version = "v0.15.0";
+
+  src =
+    if pkgs.stdenv.isDarwin then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+          sha256 = "09d9pwba6fzc08m3nkc7xni29yr12gw5fj00aa77n9kxmsba0fkb";
+        }
+    else # assume Linux
+      pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+        sha256 = "1ygp6wvbgl3y15wq1q41j9kg2ndaxr32rpgbzfzyd9zb8n9z8lpx";
+      };
+
+  # Temporary fix for https://github.com/justinwoo/easy-purescript-nix/issues/188
+  pkgs_ncurses = pkgs.extend (self: super: {
+    ncurses5 = super.ncurses5.overrideAttrs (attr: {
+      configureFlags = attr.configureFlags ++ [ "--with-versioned-syms" ];
+    });
+  });
+
+in
+import ./mkPursDerivation.nix {
+  inherit version src;
+  pkgs = pkgs_ncurses;
+}


### PR DESCRIPTION
https://github.com/purescript/purescript/releases/tag/v0.15.0

```console
$ ~ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.0/linux64.tar.gz"
path is '/nix/store/wxvzbki12ygns35gn6lql65gkhp0jn76-linux64.tar.gz'
1ygp6wvbgl3y15wq1q41j9kg2ndaxr32rpgbzfzyd9zb8n9z8lpx
$ ~ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.0/macos.tar.gz"
path is '/nix/store/p7zplc54ysghhpg4vvs541xi8zk4yric-macos.tar.gz'
09d9pwba6fzc08m3nkc7xni29yr12gw5fj00aa77n9kxmsba0fkb
```