### PR TITLE
spago: 0.20.7 → 0.20.8

### DIFF
--- a/spago.nix
+++ b/spago.nix
@@ -13,16 +13,16 @@ in
 pkgs.stdenv.mkDerivation rec {
   pname = "spago";
 
-  version = "0.20.7";
+  version = "0.20.8";
 
   src = if pkgs.stdenv.isDarwin
   then pkgs.fetchurl {
     url = "https://github.com/purescript/spago/releases/download/${version}/macOS.tar.gz";
-    sha256 = "0s5zgz4kqglsavyh7h70zmn16vayg30alp42w3nx0zwaqkp79xla";
+    sha256 = "10csxf27af303wkg216mz9x5wr5yylbwzk8lsg9f19hnav2x4c07";
   }
   else pkgs.fetchurl {
     url = "https://github.com/purescript/spago/releases/download/${version}/Linux.tar.gz";
-    sha256 = "0bh15dr1fg306kifqipnakv3rxab7hjfpcfzabw7vmg0gsfx8xka";
+    sha256 = "1ihz44y6izg3nm391ms0cabv7i2g4n9ncvql4z8xpkg79r7s0vhr";
   };
 
   buildInputs = [ pkgs.gmp pkgs.zlib pkgs.ncurses5 pkgs.stdenv.cc.cc.lib ];


### PR DESCRIPTION
2022-04-27: https://github.com/purescript/spago/releases/tag/0.20.8

```console
$ nix-prefetch-url "https://github.com/purescript/spago/releases/download/0.20.8/Linux.tar.gz"
path is '/nix/store/nv2hb5hwi82ix420z0ll1hjash98ayvr-Linux.tar.gz'
1ihz44y6izg3nm391ms0cabv7i2g4n9ncvql4z8xpkg79r7s0vhr
$ "https://github.com/purescript/spago/releases/download/0.20.8/macOS.tar.gz"
path is '/nix/store/9sdnwr1ynafc02va12cmb7hzi2sb9i53-macOS.tar.gz'
10csxf27af303wkg216mz9x5wr5yylbwzk8lsg9f19hnav2x4c07
```