### PR TITLE
zephyr: 0.3.2 → 0.4.0

### DIFF
--- a/zephyr.nix
+++ b/zephyr.nix
@@ -1,21 +1,24 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 pkgs.stdenv.mkDerivation rec {
   pname = "zephyr";
 
-  version = "0.3.2";
+  version = "0.4.0";
 
-  src = if pkgs.stdenv.isDarwin
-  then pkgs.fetchurl {
-    url = "https://github.com/coot/zephyr/releases/download/v${version}/macOS.tar.gz";
-    sha256 = "1zj2fq664akqfmczmcshg9bxlrsa2gj082bp92nkygsq6v677jk4";
-  }
-  else pkgs.fetchurl {
-    url = "https://github.com/coot/zephyr/releases/download/v${version}/Linux.tar.gz";
-    sha256 = "106qp9k1lnbxl7pich4i7bqj9gw8v895i3gp58dgcibgz4q8hymw";
-  };
+  src =
+    if pkgs.stdenv.isDarwin then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/MaybeJustJames/zephyr/releases/download/v${version}/macOS.tar.gz";
+          sha256 = "1di4zk75pw0g2hk2zq61v7msvq2ibd9wxnk21nz26fxqw09gxacd";
+        }
+    else
+      pkgs.fetchurl {
+        url = "https://github.com/MaybeJustJames/zephyr/releases/download/v${version}/Linux.tar.gz";
+        sha256 = "002rlf9s81il5x3adv7qhj0wxbnvv348l5rcllkrbivk008bb83x";
+      };
 
-  nativeBuildInputs = []
+  nativeBuildInputs = [ ]
     ++ pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.fixDarwinDylibNames;
 
   buildInputs = [ pkgs.gmp pkgs.zlib pkgs.ncurses5 ];


### PR DESCRIPTION
https://github.com/MaybeJustJames/zephyr/tree/v0.4.0

```console
$ nix-prefetch-url "https://github.com/MaybeJustJames/zephyr/releases/download/v0.4.0/Linux.tar.gz"
path is '/nix/store/dvzgql0bnrpc6j15vvnawk10n6sp302j-Linux.tar.gz'
002rlf9s81il5x3adv7qhj0wxbnvv348l5rcllkrbivk008bb83x
$ nix-prefetch-url "https://github.com/MaybeJustJames/zephyr/releases/download/v0.4.0/macOS.tar.gz"
path is '/nix/store/h42zi21304qy7gysla9q5wn2y5jn765l-macOS.tar.gz'
```