### PR TITLE
purescript: 0.15.2 → 0.15.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_15_3 = import ./purs/0.15.3.nix {
+      inherit pkgs;
+    };
+
     purs-0_15_2 = import ./purs/0.15.2.nix {
       inherit pkgs;
     };
@@ -82,7 +86,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_15_2;
+    purs = purs-0_15_3;
 
     purs-simple = purs;
 

--- a/purs/0.15.3.nix
+++ b/purs/0.15.3.nix
@@ -1,0 +1,22 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  version = "v0.15.3";
+
+  src =
+    if pkgs.stdenv.isDarwin then
+      pkgs.fetchurl
+        {
+          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+          sha256 = "01ka3j1aakcabw6kmkfbk4c2cl2prihk6g8zvc995l83snj4n403";
+        }
+    else # assume Linux
+      pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+        sha256 = "083pd5l0q2dj4ky9r4sgnfiinlch73qcvl3l26jf3nfs48y8hffv";
+      };
+
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}

--- a/purs/0.15.3.nix
+++ b/purs/0.15.3.nix
@@ -4,17 +4,18 @@ let
   version = "v0.15.3";
 
   src =
-    if pkgs.stdenv.isDarwin then
-      pkgs.fetchurl
-        {
-          url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
-          sha256 = "01ka3j1aakcabw6kmkfbk4c2cl2prihk6g8zvc995l83snj4n403";
-        }
-    else # assume Linux
-      pkgs.fetchurl {
+    if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then
+      (pkgs.fetchurl {
         url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
         sha256 = "083pd5l0q2dj4ky9r4sgnfiinlch73qcvl3l26jf3nfs48y8hffv";
-      };
+      })
+    else if pkgs.stdenv.hostPlatform.system == "x86_64-darwin" then
+      (pkgs.fetchurl {
+        url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+        sha256 = "01ka3j1aakcabw6kmkfbk4c2cl2prihk6g8zvc995l83snj4n403";
+      })
+    else
+      throw "Architecture not supported";
 
 in
 import ./mkPursDerivation.nix {

--- a/purs/0.15.3.nix
+++ b/purs/0.15.3.nix
@@ -1,22 +1,30 @@
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import <nixpkgs> { }, system ? pkgs.stdenv.hostPlatform.system }:
 
 let
   version = "v0.15.3";
 
-  src =
-    if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then
-      (pkgs.fetchurl {
-        url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
-        sha256 = "083pd5l0q2dj4ky9r4sgnfiinlch73qcvl3l26jf3nfs48y8hffv";
-      })
-    else if pkgs.stdenv.hostPlatform.system == "x86_64-darwin" then
-      (pkgs.fetchurl {
-        url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
-        sha256 = "01ka3j1aakcabw6kmkfbk4c2cl2prihk6g8zvc995l83snj4n403";
-      })
-    else
-      throw "Architecture not supported";
+  urls = {
+    "x86_64-linux" = {
+      url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+      sha256 = "083pd5l0q2dj4ky9r4sgnfiinlch73qcvl3l26jf3nfs48y8hffv";
+    };
+    "x86_64-darwin" = {
+      url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+      sha256 = "01ka3j1aakcabw6kmkfbk4c2cl2prihk6g8zvc995l83snj4n403";
+    };
+  };
 
+  src =
+    if builtins.hasAttr system urls then
+      (pkgs.fetchurl urls.${system})
+    else if system == "aarch64-darwin" then
+      let
+        useArch = "x86_64-darwin";
+        msg = "Using the non-native ${useArch} binary. While this binary may run under Rosetta 2 translation, no guarantees can be made about stability or performance.";
+      in
+      pkgs.lib.warn msg (pkgs.fetchurl urls.${useArch})
+    else
+      throw "Architecture not supported: ${system}";
 in
 import ./mkPursDerivation.nix {
   inherit pkgs version src;


### PR DESCRIPTION
```console
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.3/linux64.tar.gz"
path is '/nix/store/wgf97fn7r3d1wk52ap9aasx3dz3a0234-linux64.tar.gz'
083pd5l0q2dj4ky9r4sgnfiinlch73qcvl3l26jf3nfs48y8hffv
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.3/macos.tar.gz"
path is '/nix/store/g3mqvhy5kgb4mwbwb924jmjm2az0vd3f-macos.tar.gz'
01ka3j1aakcabw6kmkfbk4c2cl2prihk6g8zvc995l83snj4n403
```