### PR TITLE
purescript: 0.15.4 → 0.15.6

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_15_6 = import ./purs/0.15.6.nix {
+      inherit pkgs;
+    };
+
     purs-0_15_4 = import ./purs/0.15.4.nix {
       inherit pkgs;
     };
@@ -89,7 +93,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_15_4;
+    purs = purs-0_15_6;
 
     purs-simple = purs;
 

--- a/purs/0.15.6.nix
+++ b/purs/0.15.6.nix
@@ -1,0 +1,31 @@
+{ pkgs ? import <nixpkgs> { }, system ? pkgs.stdenv.hostPlatform.system }:
+
+let
+  version = "v0.15.6";
+
+  urls = {
+    "x86_64-linux" = {
+      url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+      sha256 = "1vw3igxv4zr5gf1ml5ls17w9cc9shdn8fvbk6dkfnxrs93cwrq0k";
+    };
+    "x86_64-darwin" = {
+      url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+      sha256 = "14l4m9xgp9slg4hfaqkwvzdvmg26qj2livldni3lmivvcagjgb2x";
+    };
+  };
+
+  src =
+    if builtins.hasAttr system urls then
+      (pkgs.fetchurl urls.${system})
+    else if system == "aarch64-darwin" then
+      let
+        useArch = "x86_64-darwin";
+        msg = "Using the non-native ${useArch} binary. While this binary may run under Rosetta 2 translation, no guarantees can be made about stability or performance.";
+      in
+      pkgs.lib.warn msg (pkgs.fetchurl urls.${useArch})
+    else
+      throw "Architecture not supported: ${system}";
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}


### PR DESCRIPTION
https://github.com/purescript/purescript/releases/tag/v0.15.6

```console
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.6/linux64.tar.gz"
path is '/nix/store/xl68m65ryxrlvd62b5d6w3xaabc1n79x-linux64.tar.gz' 
1vw3igxv4zr5gf1ml5ls17w9cc9shdn8fvbk6dkfnxrs93cwrq0k

$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.6/macos.tar.gz" 
path is '/nix/store/5sfla8242ik04lgqzfs4m17sqr4i9b3f-macos.tar.gz' 
14l4m9xgp9slg4hfaqkwvzdvmg26qj2livldni3lmivvcagjgb2x
```