### PR TITLE
purs: 0.15.6 → 0.15.7

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ let
   };
 
   inputs = rec {
+    purs-0_15_7 = import ./purs/0.15.7.nix {
+      inherit pkgs;
+    };
+
     purs-0_15_6 = import ./purs/0.15.6.nix {
       inherit pkgs;
     };
@@ -93,7 +97,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_15_6;
+    purs = purs-0_15_7;
 
     purs-simple = purs;
 

--- a/purs/0.15.7.nix
+++ b/purs/0.15.7.nix
@@ -1,0 +1,31 @@
+{ pkgs ? import <nixpkgs> { }, system ? pkgs.stdenv.hostPlatform.system }:
+
+let
+  version = "v0.15.7";
+
+  urls = {
+    "x86_64-linux" = {
+      url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
+      sha256 = "032jqrk46k9zbq058ms8rnrq0209rd8vkxwj73vqrlgqvpzlfl5k";
+    };
+    "x86_64-darwin" = {
+      url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
+      sha256 = "0aq5sr93z6c5l76sqbj3g48z6yrhxfqxri0x1ajmjwhcwjg79d6v";
+    };
+  };
+
+  src =
+    if builtins.hasAttr system urls then
+      (pkgs.fetchurl urls.${system})
+    else if system == "aarch64-darwin" then
+      let
+        useArch = "x86_64-darwin";
+        msg = "Using the non-native ${useArch} binary. While this binary may run under Rosetta 2 translation, no guarantees can be made about stability or performance.";
+      in
+      pkgs.lib.warn msg (pkgs.fetchurl urls.${useArch})
+    else
+      throw "Architecture not supported: ${system}";
+in
+import ./mkPursDerivation.nix {
+  inherit pkgs version src;
+}


### PR DESCRIPTION
https://github.com/purescript/purescript/releases/tag/v0.15.7

```sh-session
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.7/macos.tar.gz"
path is '/nix/store/f53v70j9aqzagkgrwwgksp4f4604swlf-macos.tar.gz'
0aq5sr93z6c5l76sqbj3g48z6yrhxfqxri0x1ajmjwhcwjg79d6v
$ nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v0.15.7/linux64.tar.gz"
path is '/nix/store/43p09j0gs8hfm3vdsqdyimhi09v3rjjz-linux64.tar.gz'
032jqrk46k9zbq058ms8rnrq0209rd8vkxwj73vqrlgqvpzlfl5k
```