### PR TITLE
deluxe shell psa and print versions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
                   psc-package
                   purp
                   spago
+                  psa
                   spago2nix
                   pscid
                   purescript-language-server
@@ -39,6 +40,25 @@
                 source <(node --completion-bash)
                 echo -e "  \033[1measy-purescript-nix deluxe development environment\033[0m"
                 echo -e "  \033[1mSee https://discourse.purescript.org/t/recommended-tooling-for-purescript-in-2022\033[0m"
+                printf "%-25s" "  purs $(purs --version)"
+                printf "%-25s" "  $(pulp --version | head -1)"
+                printf "%-25s" "  psc-package $(psc-package --version)"
+                echo ""
+                printf "%-25s" "  spago $(spago --version)"
+                printf "%-25s" "  psa $(psa --version)"
+                printf "%-25s" "  pscid $(pscid --version)"
+                echo ""
+                printf "%-25s" "  purs-tidy $(purs-tidy --version)"
+                printf "%-25s" "  purs-backend-es $(purs-backend-es --version 2>&1)"
+                printf "%-25s" "  $(purty version)"
+                echo ""
+                printf "%-25s" "  node $(node --version)"
+                printf "%-25s" "  esbuild $(esbuild --version)"
+                printf "%-25s" "  zephyr $(zephyr --version)"
+                echo ""
+                printf "%-25s" "  bower $(bower --version)"
+                printf "%-50s" "  purescript-language-server $(purescript-language-server --version)"
+                echo ""
                 '';
               };
            };


### PR DESCRIPTION
<pre>$ nix develop .#deluxe
  <b>easy-purescript-nix deluxe development environment</b>
  <b>See https://discourse.purescript.org/t/recommended-tooling-for-purescript-in-2022</b>
  purs 0.15.9              Pulp version 16.0.2      psc-package 0.6.2      
  spago 0.21.0             psa 0.8.2                pscid 2.10.0           
  purs-tidy v0.10.0        purs-backend-es v1.3.2   Purty version: 7.0.0   
  node v18.16.0            esbuild 0.17.19          zephyr 0.5.0           
  bower 1.8.14             purescript-language-server 0.17.1               
</pre>