### PR TITLE
Upgrade to purs 0.15.10 and provide aarch64-darwin builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,9 @@ let
   };
 
   inputs = rec {
+    purs-0_15_10 = import ./purs/0.15.10.nix {
+      inherit pkgs;
+    };
     purs-0_15_9 = import ./purs/0.15.9.nix {
       inherit pkgs;
     };
@@ -103,7 +106,7 @@ let
       inherit pkgs;
     };
 
-    purs = purs-0_15_9;
+    purs = purs-0_15_10;
 
     purs-simple = purs;
 

--- a/purs/0.15.10.nix
+++ b/purs/0.15.10.nix
@@ -1,20 +1,20 @@
 { pkgs ? import <nixpkgs> { }, system ? pkgs.stdenv.hostPlatform.system }:
 
 let
-  version = "v0.15.9";
+  version = "v0.15.10";
 
   urls = {
     "x86_64-linux" = {
       url = "https://github.com/purescript/purescript/releases/download/${version}/linux64.tar.gz";
-      sha256 = "0rabinklsd8bs16f03zv7ij6d1lv4w2xwvzzgkwc862gpqvz9jq3";
+      sha256 = "03p5f2m5xvrqgiacs4yfc2dgz6frlxy90h6z1nm6wan40p2vd41r";
     };
     "x86_64-darwin" = {
       url = "https://github.com/purescript/purescript/releases/download/${version}/macos.tar.gz";
-      sha256 = "1xxg79rlf7li9f73wdbwif1dyy4hnzpypy6wx4zbnvap53habq9f";
+      sha256 = "14yd00v3dsnnwj2f645vy0apnp1843ms9ffd2ccv7bj5p4kxsdzg";
     };
     "aarch64-darwin" = {
       url = "https://github.com/purescript/purescript/releases/download/${version}/macos-arm64.tar.gz";
-      sha256 = "16ci26pgrw0zmnyn1zj129y9624cqwzrhqglc8mgfg4k7rxvqy2a";
+      sha256 = "1pk6mkjy09qvh8lsygb5gb77i2fqwjzz8jdjkxlyzynp3wpkcjp7";
     };
   };
 


### PR DESCRIPTION
Hi there,

I've added `purescript` `v0.15.10` which was released a couple of days ago. I also added the `aarch64-darwin` binary which will remove the warning:
```
Using the non-native x86_64-darwin binary. While this binary may run under Rosetta 2 translation, no guarantees can be made about stability or performance.
```

I also took the liberty to enable the `aarch64-darwin` architecture for `0.15.9` which was [the first release providing the build](https://github.com/purescript/purescript/releases/tag/v0.15.9). The only remaining package in `easy-purescript-nix` that doesn't support the architecture is `zephyr`  https://github.com/MaybeJustJames/zephyr/issues/82 

When [commenting it out from the flake's shell](https://github.com/justinwoo/easy-purescript-nix/blob/master/flake.nix#L31) it's possible to run `nix develop .#devShells.aarch64-darwin.deluxe`

This was only tested on a macos machine so far.

Cheers,

Jun